### PR TITLE
Allow configuring custom Redis key prefix

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -3,14 +3,16 @@ package httprateredis
 import "github.com/redis/go-redis/v9"
 
 type Config struct {
-	// Client if supplied will be used and other configs will be ignored.
-	Client     *redis.Client `toml:"-"`
-	Host       string        `toml:"host"`
-	Port       uint16        `toml:"port"`
-	Password   string        `toml:"password"`   // optional
-	DBIndex    int           `toml:"db_index"`   // default 0
-	MaxIdle    int           `toml:"max_idle"`   // default 4
-	MaxActive  int           `toml:"max_active"` // default 8
-	ClientName string        `toml:"client_name"`
-	Disabled   bool          `toml:"disabled"` // default false
+	// Client if supplied will be used and below fields will be ignored.
+	Client    *redis.Client `toml:"-"`
+	Host      string        `toml:"host"`
+	Port      uint16        `toml:"port"`
+	Password  string        `toml:"password"`   // optional
+	DBIndex   int           `toml:"db_index"`   // default 0
+	MaxIdle   int           `toml:"max_idle"`   // default 4
+	MaxActive int           `toml:"max_active"` // default 8
+
+	ClientName string `toml:"client_name"` // default os.Args[0]
+	Disabled   bool   `toml:"disabled"`    // default false
+	PrefixKey  string `toml:"prefix_key"`  // default "httprate"
 }


### PR DESCRIPTION
To allow per-service/group rate-limiting.
To allow running tests concurrently.

Also, set binary name as a default ClientName. This will show up as `name=<binary>` in `CLIENT LIST` command.