### PR TITLE
Expire Redis keys faster

### DIFF
--- a/httprateredis.go
+++ b/httprateredis.go
@@ -105,7 +105,7 @@ func (c *redisCounter) IncrementBy(key string, currentWindow time.Time, amount i
 
 	pipe := conn.TxPipeline()
 	incrCmd := pipe.IncrBy(ctx, hkey, int64(amount))
-	expireCmd := pipe.Expire(ctx, hkey, (c.windowLength*2)+time.Second)
+	expireCmd := pipe.Expire(ctx, hkey, c.windowLength*2+time.Second)
 	_, err := pipe.Exec(ctx)
 	if err != nil {
 		return fmt.Errorf("httprateredis: redis transaction failed: %w", err)

--- a/httprateredis.go
+++ b/httprateredis.go
@@ -105,7 +105,7 @@ func (c *redisCounter) IncrementBy(key string, currentWindow time.Time, amount i
 
 	pipe := conn.TxPipeline()
 	incrCmd := pipe.IncrBy(ctx, hkey, int64(amount))
-	expireCmd := pipe.Expire(ctx, hkey, c.windowLength*3)
+	expireCmd := pipe.Expire(ctx, hkey, (c.windowLength*2)+time.Second)
 	_, err := pipe.Exec(ctx)
 	if err != nil {
 		return fmt.Errorf("httprateredis: redis transaction failed: %w", err)


### PR DESCRIPTION
We don't need to keep the old (third) window key in Redis for too long, especially when using longer window lengths (e.g. time.Minute). Keeping the extra window key around for an extra second should be enough.

NOTE: The smallest `EXPIRE` value in Redis is 1s, so this will also ensure that the expiry works correctly even on short window lengths like 100ms.