### PR TITLE
NewRedisLimitCounter: no error to return

### DIFF
--- a/_example/main.go
+++ b/_example/main.go
@@ -19,7 +19,7 @@ func main() {
 	// Expose Prometheus endpoint at /metrics path.
 	r.Use(telemetry.Collector(telemetry.Config{AllowAny: true}))
 
-	rc, _ := httprateredis.NewRedisLimitCounter(&httprateredis.Config{
+	rc := httprateredis.NewRedisLimitCounter(&httprateredis.Config{
 		Host: "127.0.0.1", Port: 6379,
 	})
 

--- a/_example/main.go
+++ b/_example/main.go
@@ -19,7 +19,7 @@ func main() {
 	// Expose Prometheus endpoint at /metrics path.
 	r.Use(telemetry.Collector(telemetry.Config{AllowAny: true}))
 
-	rc := httprateredis.NewRedisLimitCounter(&httprateredis.Config{
+	rc := httprateredis.NewCounter(&httprateredis.Config{
 		Host: "127.0.0.1", Port: 6379,
 	})
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/go-chi/httprate-redis
 go 1.19
 
 require (
+	github.com/alicebob/miniredis/v2 v2.33.0
 	github.com/go-chi/httprate v0.12.0
 	github.com/redis/go-redis/v9 v9.6.1
 	golang.org/x/sync v0.7.0
@@ -10,7 +11,6 @@ require (
 
 require (
 	github.com/alicebob/gopher-json v0.0.0-20230218143504-906a9b012302 // indirect
-	github.com/alicebob/miniredis/v2 v2.33.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/yuin/gopher-lua v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,6 @@ github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/r
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/go-chi/httprate v0.12.0 h1:08D/te3pOTJe5+VAZTQrHxwdsH2NyliiUoRD1naKaMg=
 github.com/go-chi/httprate v0.12.0/go.mod h1:TUepLXaz/pCjmCtf/obgOQJ2Sz6rC8fSf5cAt5cnTt0=
-github.com/redis/go-redis/v9 v9.6.0 h1:NLck+Rab3AOTHw21CGRpvQpgTrAU4sgdCswqGtlhGRA=
-github.com/redis/go-redis/v9 v9.6.0/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0b/CLO2V2M=
 github.com/redis/go-redis/v9 v9.6.1 h1:HHDteefn6ZkTtY5fGUE8tj8uy85AHk6zP7CpzIAM0y4=
 github.com/redis/go-redis/v9 v9.6.1/go.mod h1:0C0c6ycQsdpVNQpxb1njEQIqkx5UcsM8FJCQLgE9+RA=
 github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=

--- a/httprateredis.go
+++ b/httprateredis.go
@@ -17,11 +17,10 @@ func WithRedisLimitCounter(cfg *Config) httprate.Option {
 	if cfg.Disabled {
 		return httprate.WithNoop()
 	}
-	rc, _ := NewRedisLimitCounter(cfg)
-	return httprate.WithLimitCounter(rc)
+	return httprate.WithLimitCounter(NewRedisLimitCounter(cfg))
 }
 
-func NewRedisLimitCounter(cfg *Config) (*redisCounter, error) {
+func NewRedisLimitCounter(cfg *Config) *redisCounter {
 	if cfg == nil {
 		cfg = &Config{}
 	}
@@ -90,7 +89,7 @@ func NewRedisLimitCounter(cfg *Config) (*redisCounter, error) {
 		})
 	}
 
-	return rc, nil
+	return rc
 }
 
 type redisCounter struct {

--- a/httprateredis.go
+++ b/httprateredis.go
@@ -17,10 +17,18 @@ func WithRedisLimitCounter(cfg *Config) httprate.Option {
 	if cfg.Disabled {
 		return httprate.WithNoop()
 	}
-	return httprate.WithLimitCounter(NewRedisLimitCounter(cfg))
+	return httprate.WithLimitCounter(NewCounter(cfg))
 }
 
-func NewRedisLimitCounter(cfg *Config) *redisCounter {
+func NewRedisLimitCounter(cfg *Config) (*redisCounter, error) {
+	c := NewCounter(cfg)
+	if err := c.client.Ping(context.Background()).Err(); err != nil {
+		return nil, fmt.Errorf("ping failed: %w", err)
+	}
+	return c, nil
+}
+
+func NewCounter(cfg *Config) *redisCounter {
 	if cfg == nil {
 		cfg = &Config{}
 	}

--- a/httprateredis_test.go
+++ b/httprateredis_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestRedisCounter(t *testing.T) {
-	limitCounter := httprateredis.NewRedisLimitCounter(&httprateredis.Config{
+	limitCounter := httprateredis.NewCounter(&httprateredis.Config{
 		Host:             "localhost",
 		Port:             6379,
 		MaxIdle:          0,
@@ -153,7 +153,7 @@ func TestRedisCounter(t *testing.T) {
 }
 
 func BenchmarkLocalCounter(b *testing.B) {
-	limitCounter := httprateredis.NewRedisLimitCounter(&httprateredis.Config{
+	limitCounter := httprateredis.NewCounter(&httprateredis.Config{
 		Host:             "localhost",
 		Port:             6379,
 		DBIndex:          0,

--- a/httprateredis_test.go
+++ b/httprateredis_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestRedisCounter(t *testing.T) {
-	limitCounter, err := httprateredis.NewRedisLimitCounter(&httprateredis.Config{
+	limitCounter := httprateredis.NewRedisLimitCounter(&httprateredis.Config{
 		Host:             "localhost",
 		Port:             6379,
 		MaxIdle:          0,
@@ -23,9 +23,6 @@ func TestRedisCounter(t *testing.T) {
 		FallbackTimeout:  time.Second,
 		FallbackDisabled: true,
 	})
-	if err != nil {
-		t.Fatalf("redis not available: %v", err)
-	}
 	defer limitCounter.Close()
 
 	limitCounter.Config(1000, time.Minute)
@@ -156,7 +153,7 @@ func TestRedisCounter(t *testing.T) {
 }
 
 func BenchmarkLocalCounter(b *testing.B) {
-	limitCounter, err := httprateredis.NewRedisLimitCounter(&httprateredis.Config{
+	limitCounter := httprateredis.NewRedisLimitCounter(&httprateredis.Config{
 		Host:             "localhost",
 		Port:             6379,
 		DBIndex:          0,
@@ -167,9 +164,6 @@ func BenchmarkLocalCounter(b *testing.B) {
 		FallbackDisabled: true,
 		FallbackTimeout:  5 * time.Second,
 	})
-	if err != nil {
-		b.Fatalf("redis not available: %v", err)
-	}
 	defer limitCounter.Close()
 
 	limitCounter.Config(1000, time.Minute)

--- a/local_fallback_test.go
+++ b/local_fallback_test.go
@@ -22,7 +22,7 @@ func TestLocalFallback(t *testing.T) {
 	var onErrorCalled bool
 	var onFallbackCalled bool
 
-	limitCounter := httprateredis.NewRedisLimitCounter(&httprateredis.Config{
+	limitCounter := httprateredis.NewCounter(&httprateredis.Config{
 		Host:             redis.Host(),
 		Port:             uint16(redisPort),
 		MaxIdle:          0,

--- a/local_fallback_test.go
+++ b/local_fallback_test.go
@@ -14,12 +14,15 @@ import (
 // Test local in-memory counter fallback, which gets activated in case Redis is not available.
 func TestLocalFallback(t *testing.T) {
 	redis, err := miniredis.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
 	redisPort, _ := strconv.Atoi(redis.Port())
 
 	var onErrorCalled bool
 	var onFallbackCalled bool
 
-	limitCounter, err := httprateredis.NewRedisLimitCounter(&httprateredis.Config{
+	limitCounter := httprateredis.NewRedisLimitCounter(&httprateredis.Config{
 		Host:             redis.Host(),
 		Port:             uint16(redisPort),
 		MaxIdle:          0,
@@ -30,9 +33,6 @@ func TestLocalFallback(t *testing.T) {
 		OnError:          func(err error) { onErrorCalled = true },
 		OnFallbackChange: func(fallbackActivated bool) { onFallbackCalled = true },
 	})
-	if err != nil {
-		t.Fatalf("redis not available: %v", err)
-	}
 
 	limitCounter.Config(1000, time.Minute)
 


### PR DESCRIPTION
NewRedisLimitCounter used to return an error when trying to pin, but that is not the case anymore. Let's remove the error from the return arguments to simplify the code.