### PR TITLE
Relax the fallback timeout by default

### DIFF
--- a/httprateredis.go
+++ b/httprateredis.go
@@ -50,7 +50,7 @@ func NewCounter(cfg *Config) *redisCounter {
 		} else {
 			// Activate local in-memory fallback fairly quickly,
 			// so we don't slow down incoming requests too much.
-			cfg.FallbackTimeout = 100 * time.Millisecond
+			cfg.FallbackTimeout = 250 * time.Millisecond
 		}
 	}
 


### PR DESCRIPTION
Increase the default fallback timeout, to give Redis over network more time before falling back to local in-memory-counter. Users can override this value.