### PR TITLE
ClientName optional config, and do not auto-set it

### DIFF
--- a/config.go
+++ b/config.go
@@ -10,7 +10,7 @@ type Config struct {
 	Disabled bool `toml:"disabled"` // default: false
 
 	WindowLength time.Duration `toml:"window_length"` // default: 1m
-	ClientName   string        `toml:"client_name"`   // default: os.Args[0]
+	ClientName   string        `toml:"client_name"`   // default: ""
 	PrefixKey    string        `toml:"prefix_key"`    // default: "httprate"
 
 	// OnError lets you subscribe to all runtime Redis errors. Useful for logging/debugging.
@@ -39,12 +39,4 @@ type Config struct {
 	DBIndex   int           `toml:"db_index"`   // default: 0
 	MaxIdle   int           `toml:"max_idle"`   // default: 5
 	MaxActive int           `toml:"max_active"` // default: 10
-
-	Backend Backend `toml:"backend"` // default: ""
 }
-
-type Backend string
-
-const (
-	BackendMemoryStore Backend = "memory-store"
-)

--- a/config.go
+++ b/config.go
@@ -40,11 +40,11 @@ type Config struct {
 	MaxIdle   int           `toml:"max_idle"`   // default: 5
 	MaxActive int           `toml:"max_active"` // default: 10
 
-	Provider Provider `toml:"provider"` // default: ""
+	Backend Backend `toml:"backend"` // default: ""
 }
 
-type Provider string
+type Backend string
 
 const (
-	ProviderMemoryStore Provider = "memory-store"
+	BackendMemoryStore Backend = "memory-store"
 )

--- a/config.go
+++ b/config.go
@@ -39,4 +39,12 @@ type Config struct {
 	DBIndex   int           `toml:"db_index"`   // default: 0
 	MaxIdle   int           `toml:"max_idle"`   // default: 5
 	MaxActive int           `toml:"max_active"` // default: 10
+
+	Provider Provider `toml:"provider"` // default: ""
 }
+
+type Provider string
+
+const (
+	ProviderMemoryStore Provider = "memory-store"
+)

--- a/httprateredis.go
+++ b/httprateredis.go
@@ -38,7 +38,8 @@ func NewCounter(cfg *Config) *redisCounter {
 	if cfg.Port < 1 {
 		cfg.Port = 6379
 	}
-	if cfg.ClientName == "" {
+	// MemoryStore does not support client setname.
+	if cfg.Provider != ProviderMemoryStore && cfg.ClientName == "" {
 		cfg.ClientName = filepath.Base(os.Args[0])
 	}
 	if cfg.PrefixKey == "" {

--- a/httprateredis.go
+++ b/httprateredis.go
@@ -39,7 +39,7 @@ func NewCounter(cfg *Config) *redisCounter {
 		cfg.Port = 6379
 	}
 	// MemoryStore does not support client setname.
-	if cfg.Provider != ProviderMemoryStore && cfg.ClientName == "" {
+	if cfg.Backend != BackendMemoryStore && cfg.ClientName == "" {
 		cfg.ClientName = filepath.Base(os.Args[0])
 	}
 	if cfg.PrefixKey == "" {

--- a/httprateredis.go
+++ b/httprateredis.go
@@ -3,8 +3,6 @@ package httprateredis
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strconv"
 	"sync/atomic"
 	"time"
@@ -37,10 +35,6 @@ func NewCounter(cfg *Config) *redisCounter {
 	}
 	if cfg.Port < 1 {
 		cfg.Port = 6379
-	}
-	// MemoryStore does not support client setname.
-	if cfg.Backend != BackendMemoryStore && cfg.ClientName == "" {
-		cfg.ClientName = filepath.Base(os.Args[0])
 	}
 	if cfg.PrefixKey == "" {
 		cfg.PrefixKey = "httprate"


### PR DESCRIPTION
GCP MemoryStore does not allow `client setname` and redis client tries to set the name when the value in the options is not empty.

The conditional settings of the value should allow avoiding the forbidden operation.